### PR TITLE
Allow clock implementation to be replaced

### DIFF
--- a/spec/clock_spec.cr
+++ b/spec/clock_spec.cr
@@ -1,0 +1,39 @@
+require "./spec_helper"
+
+describe OpenTelemetry::Clock do
+  it "allows a clock to be set and used for span generation" do
+    start = Time.utc
+    start_monotonic = Time::Span.new(nanoseconds: 5)
+    start_clock = FixedClock.new(start, start_monotonic)
+
+    finish = start.shift(nanoseconds: 100)
+    finish_monotonic = start_monotonic + Time::Span.new(nanoseconds: 100)
+    finish_clock = FixedClock.new(finish, finish_monotonic)
+
+    checkout_config do
+      provider = OpenTelemetry::TraceProvider.new(
+        service_name: "my_app_or_library",
+        service_version: "1.1.1",
+        exporter: OpenTelemetry::Exporter.new(variant: :null))
+
+      trace = provider.trace do |t|
+        t.service_name = "microservice"
+        t.service_version = "1.2.3"
+      end
+
+      span = OpenTelemetry.with_clock(start_clock) do
+        trace.in_span("request")
+      end
+
+      OpenTelemetry.with_clock(finish_clock) do
+        trace.close_span
+      end
+
+      span.start.should eq(start_monotonic)
+      span.wall_start.should eq(start)
+
+      span.finish.should eq(finish_monotonic)
+      span.wall_finish.should eq(finish)
+    end
+  end
+end

--- a/spec/opentelemetry-api_spec.cr
+++ b/spec/opentelemetry-api_spec.cr
@@ -131,4 +131,16 @@ describe OpenTelemetry do
       iterate_tracer_spans(trace.not_nil!).map(&.name).should eq ["request", "handler", "external api", "db"]
     end
   end
+
+  it "sets clock and reverts after block" do
+    original_clock = OpenTelemetry.clock
+
+    clock = FixedClock.new(now: Time.utc, monotonic: Time::Span.new(nanoseconds: 5))
+
+    OpenTelemetry.with_clock(clock) do
+      OpenTelemetry.clock.should eq(clock)
+    end
+
+    OpenTelemetry.clock.should eq(original_clock)
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -91,3 +91,16 @@ class FindJson
     json
   end
 end
+
+class FixedClock < OpenTelemetry::Clock
+  def initialize(@now : Time, @monotonic : Time::Span)
+  end
+
+  def utc : Time
+    @now
+  end
+
+  def monotonic : Time::Span
+    @monotonic
+  end
+end

--- a/src/clock.cr
+++ b/src/clock.cr
@@ -1,0 +1,18 @@
+module OpenTelemetry
+  abstract class Clock
+    abstract def monotonic : Time::Span
+    abstract def utc : Time
+  end
+
+  class TimeClock < Clock
+    @[AlwaysInline]
+    def monotonic : Time::Span
+      Time.monotonic
+    end
+
+    @[AlwaysInline]
+    def utc : Time
+      Time.utc
+    end
+  end
+end

--- a/src/event.cr
+++ b/src/event.cr
@@ -3,8 +3,8 @@ require "opentelemetry-api/src/api/abstract_event"
 module OpenTelemetry
   class Event < OpenTelemetry::API::AbstractEvent
     property name : String = ""
-    property timestamp : Time::Span = Time.monotonic
-    property wall_timestamp : Time = Time.utc
+    property timestamp : Time::Span = OpenTelemetry.clock.monotonic
+    property wall_timestamp : Time = OpenTelemetry.clock.utc
     getter attributes : Hash(String, AnyAttribute) = {} of String => AnyAttribute
     property parent_span : Span? = nil
 

--- a/src/opentelemetry-sdk.cr
+++ b/src/opentelemetry-sdk.cr
@@ -1,6 +1,7 @@
 require "opentelemetry-api/interfaces"
 require "./ext"
 require "csuuid"
+require "./clock"
 require "./resource"
 require "./trace_flags"
 require "./name"
@@ -76,6 +77,9 @@ module OpenTelemetry
 
   # `provider` class property provides direct access to the global default Tracerprovider instance.
   class_property provider : TraceProvider = TraceProvider.new.configure!(@@config)
+
+  # `clock` class property allows alternative implementations for testing or simulations
+  class_property clock : Clock = TimeClock.new
 
   # Use this method to configure the global trace provider. The provided block will receive a `OpenTelemetry::Provider::Configuration::Factory`
   # instance, which will be used to generate a `OpenTelemetry::Provider::Configuration` struct instance.
@@ -281,5 +285,16 @@ module OpenTelemetry
   end
 
   def self.handle_error(error)
+  end
+
+  def self.with_clock(clock : Clock)
+    original_clock = self.clock
+
+    begin
+      self.clock = clock
+      yield
+    ensure
+      self.clock = original_clock
+    end
   end
 end

--- a/src/span.cr
+++ b/src/span.cr
@@ -11,8 +11,8 @@ module OpenTelemetry
     include Sendable
 
     property name : String = ""
-    property start : Time::Span = Time.monotonic
-    property wall_start : Time = Time.utc
+    property start : Time::Span = OpenTelemetry.clock.monotonic
+    property wall_start : Time = OpenTelemetry.clock.utc
     property finish : Time::Span? = nil
     property wall_finish : Time? = nil
     property events : Array(Event) = [] of Event

--- a/src/trace.cr
+++ b/src/trace.cr
@@ -260,8 +260,8 @@ module OpenTelemetry
 
     @[AlwaysInline]
     private def close_span_impl(span)
-      span.finish = Time.monotonic
-      span.wall_finish = Time.utc
+      span.finish = OpenTelemetry.clock.monotonic
+      span.wall_finish = OpenTelemetry.clock.utc
       if @span_stack.last == span
         candidate_span = @span_stack.pop
         @output_stack.unshift(candidate_span) if candidate_span.can_export?


### PR DESCRIPTION
I am using your opentelemetry libraries in an application I am working to generate traces for a collector I am building The libraries have been great to work with so far! This proposed change allows me to substitute in a new clock implementation to advance time without having to `sleep` or wait so I can generate traces that "take minutes" etc instantly. 

**Example clock**

```crystal
class FakeClock < OpenTelemetry::Clock
  def initialize
    @now = Time.utc
    @tick = Time.monotonic
  end

  def advance(nanoseconds : Int64)
    @now = @now.shift(nanoseconds: nanoseconds)
    @tick += Time::Span.new(nanoseconds: nanoseconds)
  end

  def monotonic : Time::Span
    @tick
  end

  def utc : Time
    @now
  end
end
```

```crystal
trace.in_span do |span|
  # Advance time by 1 second
  clock.advance(nanoseconds: 1_000i64 * 1_000i64 * 1_000i64)
end
```

I have also added a utility method `with_clock` that allows the clock to be overridden and reset back to it's original implementation. 

**Update** Looks like the CI hasn't run due to inactivity on this project and the workflow needs to be re-enabled.